### PR TITLE
Update AcrylicViewHandler.cs to make sure all styles are applied correctly

### DIFF
--- a/AcrylicView.Samples/AcrylicView.Samples.csproj
+++ b/AcrylicView.Samples/AcrylicView.Samples.csproj
@@ -70,8 +70,8 @@
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-ios'">
 	  <ProvisioningType>manual</ProvisioningType>
-	  <CodesignKey>Apple Development: Created via API (7TALY84B6W)</CodesignKey>
-	  <CodesignProvision>vs</CodesignProvision>
+	  <CodesignKey>iPhone Developer</CodesignKey>
+	  <CodesignProvision></CodesignProvision>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/AcrylicView.Samples/MainPage.xaml
+++ b/AcrylicView.Samples/MainPage.xaml
@@ -1,153 +1,366 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:ui="clr-namespace:Xe.AcrylicView;assembly=Xe.AcrylicView" 
-             x:Class="AcrylicView.Samples.MainPage" NavigationPage.HasNavigationBar="False" >
+<ContentPage
+    x:Class="AcrylicView.Samples.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:ui="clr-namespace:Xe.AcrylicView;assembly=Xe.AcrylicView"
+    NavigationPage.HasNavigationBar="False">
 
     <Grid IgnoreSafeArea="True">
-        <Image Source="nature.jpg" Aspect="AspectFill"/>
+        <Image Aspect="AspectFill" Source="nature.jpg" />
 
 
         <ScrollView>
-            
-            
-            
-            
-            <Grid RowDefinitions="120,170,120,120,120,*"  Padding="20" RowSpacing="30">
 
-                <ui:AcrylicView  EffectStyle="Light"      BorderColor="LightCyan" BorderThickness="1" CornerRadius="20" >
-                    <Grid ColumnDefinitions="*,*,*,*" Padding="20,0">
+
+
+
+            <Grid
+                Padding="20"
+                RowDefinitions="120,170,120,120,120,*"
+                RowSpacing="30">
+
+                <ui:AcrylicView
+                    BorderColor="LightCyan"
+                    BorderThickness="1"
+                    CornerRadius="20"
+                    EffectStyle="Light">
+                    <Grid Padding="20,0" ColumnDefinitions="*,*,*,*">
                         <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE72F;" FontFamily="XF" FontSize="60" TextColor="White"/>
-                            <Label Text="QQ" HorizontalOptions="Center"/>
+                            <Label
+                                FontFamily="XF"
+                                FontSize="60"
+                                Text="&#xE72F;"
+                                TextColor="White" />
+                            <Label HorizontalOptions="Center" Text="QQ" />
                         </VerticalStackLayout>
 
-                        <VerticalStackLayout Grid.Column="1" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE71F;" FontFamily="XF" FontSize="60" TextColor="White"/>
-                            <Label Text="AliPay" HorizontalOptions="Center"/>
+                        <VerticalStackLayout
+                            Grid.Column="1"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="60"
+                                Text="&#xE71F;"
+                                TextColor="White" />
+                            <Label HorizontalOptions="Center" Text="AliPay" />
                         </VerticalStackLayout>
 
-                        <VerticalStackLayout Grid.Column="2" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE738;" FontFamily="XF" FontSize="60" TextColor="White"/>
-                            <Label Text="WeChat" HorizontalOptions="Center"/>
-                        </VerticalStackLayout>
-                        
-                        <VerticalStackLayout Grid.Column="3" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE6F8;" FontFamily="XF" FontSize="60" TextColor="White"/>
-                            <Label Text="CCB" HorizontalOptions="Center"/>
-                        </VerticalStackLayout>                       
-
-                    </Grid>
-                </ui:AcrylicView>
-
-                <ui:AcrylicView  Grid.Row="1"  EffectStyle="ExtraDark"       CornerRadius="20" >
-                    <Grid  ColumnDefinitions="*,*,*,*" RowDefinitions="*,*" Padding="20,10" RowSpacing="15">
-                        <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE62A;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Theme" HorizontalOptions="Center" FontSize="10"/>
+                        <VerticalStackLayout
+                            Grid.Column="2"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="60"
+                                Text="&#xE738;"
+                                TextColor="White" />
+                            <Label HorizontalOptions="Center" Text="WeChat" />
                         </VerticalStackLayout>
 
-                        <VerticalStackLayout Grid.Column="1" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE622;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Message" HorizontalOptions="Center" FontSize="10"/>
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout Grid.Column="2" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE60F;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Music" HorizontalOptions="Center" FontSize="10"/>
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout Grid.Column="3" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE61D;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Setting" HorizontalOptions="Center" FontSize="10"/>
-                        </VerticalStackLayout>
-
-<!--ROW2-->
-                        <VerticalStackLayout Grid.Row="1" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE68A;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Mail" HorizontalOptions="Center" FontSize="10"/>
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout Grid.Row="1" Grid.Column="1" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE68D;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Photo" HorizontalOptions="Center" FontSize="10"/>
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout Grid.Row="1" Grid.Column="2" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE6A3;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Phone" HorizontalOptions="Center" FontSize="10"/>
-                        </VerticalStackLayout>
-
-                        <VerticalStackLayout Grid.Row="1" Grid.Column="3" HorizontalOptions="Center" VerticalOptions="Center">
-                            <Label Text="&#xE731;" FontFamily="XF" FontSize="40" TextColor="White"/>
-                            <Label Text="Clock" HorizontalOptions="Center" FontSize="10"/>
+                        <VerticalStackLayout
+                            Grid.Column="3"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="60"
+                                Text="&#xE6F8;"
+                                TextColor="White" />
+                            <Label HorizontalOptions="Center" Text="CCB" />
                         </VerticalStackLayout>
 
                     </Grid>
                 </ui:AcrylicView>
 
-                <Grid Grid.Row="2" ColumnDefinitions="*,*,*,*" ColumnSpacing="15">                    
-                    
-                    <ui:AcrylicView EffectStyle="ExtraLight"  CornerRadius="10">
-                        <Grid>
-                            <Label Text="ExtraLight" HorizontalOptions="Center" VerticalOptions="Center"/>
-                        </Grid>     
-                    </ui:AcrylicView>
+                <ui:AcrylicView
+                    Grid.Row="1"
+                    CornerRadius="20"
+                    EffectStyle="ExtraDark">
+                    <Grid
+                        Padding="20,10"
+                        ColumnDefinitions="*,*,*,*"
+                        RowDefinitions="*,*"
+                        RowSpacing="15">
+                        <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE62A;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Theme" />
+                        </VerticalStackLayout>
 
+                        <VerticalStackLayout
+                            Grid.Column="1"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE622;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Message" />
+                        </VerticalStackLayout>
 
-                    <ui:AcrylicView Grid.Column="1" EffectStyle="Light"  CornerRadius="10">
+                        <VerticalStackLayout
+                            Grid.Column="2"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE60F;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Music" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout
+                            Grid.Column="3"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE61D;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Setting" />
+                        </VerticalStackLayout>
+
+                        <!--  ROW2  -->
+                        <VerticalStackLayout
+                            Grid.Row="1"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE68A;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Mail" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE68D;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Photo" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE6A3;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Phone" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout
+                            Grid.Row="1"
+                            Grid.Column="3"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                            <Label
+                                FontFamily="XF"
+                                FontSize="40"
+                                Text="&#xE731;"
+                                TextColor="White" />
+                            <Label
+                                FontSize="10"
+                                HorizontalOptions="Center"
+                                Text="Clock" />
+                        </VerticalStackLayout>
+
+                    </Grid>
+                </ui:AcrylicView>
+
+                <Grid
+                    Grid.Row="2"
+                    ColumnDefinitions="*,*,*,*"
+                    ColumnSpacing="15">
+
+                    <ui:AcrylicView CornerRadius="10" EffectStyle="ExtraLight">
                         <Grid>
-                            <Label Text="Light" HorizontalOptions="Center" VerticalOptions="Center"/>
+                            <Label
+                                HorizontalOptions="Center"
+                                Text="ExtraLight"
+                                VerticalOptions="Center" />
                         </Grid>
                     </ui:AcrylicView>
 
-                    <ui:AcrylicView Grid.Column="2" EffectStyle="Dark"  CornerRadius="10">
+
+                    <ui:AcrylicView
+                        Grid.Column="1"
+                        CornerRadius="10"
+                        EffectStyle="Light">
                         <Grid>
-                            <Label Text="Dark" HorizontalOptions="Center" VerticalOptions="Center"/>
+                            <Label
+                                HorizontalOptions="Center"
+                                Text="Light"
+                                VerticalOptions="Center" />
                         </Grid>
                     </ui:AcrylicView>
 
-                    <ui:AcrylicView Grid.Column="3" EffectStyle="ExtraDark"  CornerRadius="10">
+                    <ui:AcrylicView
+                        Grid.Column="2"
+                        CornerRadius="10"
+                        EffectStyle="Dark">
                         <Grid>
-                            <Label Text="ExtraDark" HorizontalOptions="Center" VerticalOptions="Center"/>
+                            <Label
+                                HorizontalOptions="Center"
+                                Text="Dark"
+                                VerticalOptions="Center" />
+                        </Grid>
+                    </ui:AcrylicView>
+
+                    <ui:AcrylicView
+                        Grid.Column="3"
+                        CornerRadius="10"
+                        EffectStyle="ExtraDark">
+                        <Grid>
+                            <Label
+                                HorizontalOptions="Center"
+                                Text="ExtraDark"
+                                VerticalOptions="Center" />
                         </Grid>
                     </ui:AcrylicView>
 
                 </Grid>
 
-                <Grid Grid.Row="3" ColumnDefinitions="*,*,*,*" ColumnSpacing="15">
+                <Grid
+                    Grid.Row="3"
+                    ColumnDefinitions="*,*,*,*"
+                    ColumnSpacing="15">
 
-                    <ui:AcrylicView EffectStyle="Custom" TintColor="OrangeRed" TintOpacity=".3" WidthRequest="80" HeightRequest="80" CornerRadius="40"/>
+                    <ui:AcrylicView
+                        CornerRadius="40"
+                        EffectStyle="Custom"
+                        HeightRequest="80"
+                        TintColor="OrangeRed"
+                        TintOpacity=".3"
+                        WidthRequest="80" />
 
-                    <ui:AcrylicView Grid.Column="1" EffectStyle="Custom" TintColor="BlueViolet" TintOpacity=".2"   WidthRequest="80" HeightRequest="80" CornerRadius="10"/>
+                    <ui:AcrylicView
+                        Grid.Column="1"
+                        CornerRadius="10"
+                        EffectStyle="Custom"
+                        HeightRequest="80"
+                        TintColor="BlueViolet"
+                        TintOpacity=".2"
+                        WidthRequest="80" />
 
-                    <ui:AcrylicView Grid.Column="2" EffectStyle="Custom" TintColor="Blue" TintOpacity=".2"   CornerRadius="10,30,60,60"  WidthRequest="80" HeightRequest="80"/>
+                    <ui:AcrylicView
+                        Grid.Column="2"
+                        CornerRadius="10,30,60,60"
+                        EffectStyle="Custom"
+                        HeightRequest="80"
+                        TintColor="Blue"
+                        TintOpacity=".2"
+                        WidthRequest="80" />
 
-                    <ui:AcrylicView Grid.Column="3"  EffectStyle="Custom"  TintColor="AliceBlue" TintOpacity=".3" CornerRadius="8,50" WidthRequest="80" HeightRequest="80"/>
+                    <ui:AcrylicView
+                        Grid.Column="3"
+                        CornerRadius="8,50"
+                        EffectStyle="Custom"
+                        HeightRequest="80"
+                        TintColor="AliceBlue"
+                        TintOpacity=".3"
+                        WidthRequest="80" />
 
                 </Grid>
 
 
-                <Grid Grid.Row="4" ColumnDefinitions="*,*,*,*" ColumnSpacing="15">
+                <Grid
+                    Grid.Row="4"
+                    ColumnDefinitions="*,*,*,*"
+                    ColumnSpacing="15">
 
-                    <ui:AcrylicView EffectStyle="Custom" BorderThickness="2" BorderColor="OrangeRed" TintColor="OrangeRed" TintOpacity=".3" WidthRequest="80" HeightRequest="80" CornerRadius="60"/>
+                    <ui:AcrylicView
+                        BorderColor="OrangeRed"
+                        BorderThickness="2"
+                        CornerRadius="60"
+                        EffectStyle="Dark"
+                        HeightRequest="80"
+                        TintColor="OrangeRed"
+                        TintOpacity=".3"
+                        WidthRequest="80" />
 
-                    <ui:AcrylicView Grid.Column="1" EffectStyle="Custom" BorderThickness="0,5" BorderColor="BlueViolet" TintColor="BlueViolet" TintOpacity=".2"   WidthRequest="80" HeightRequest="80" CornerRadius="10"/>
+                    <ui:AcrylicView
+                        Grid.Column="1"
+                        BorderColor="BlueViolet"
+                        BorderThickness="0,5"
+                        CornerRadius="10"
+                        EffectStyle="Custom"
+                        HeightRequest="80"
+                        TintColor="BlueViolet"
+                        TintOpacity=".2"
+                        WidthRequest="80" />
 
-                    <ui:AcrylicView Grid.Column="2" EffectStyle="Custom"  BorderThickness="0,5,10,3" BorderColor="Gray" TintColor="Blue" TintOpacity=".2"   CornerRadius="10,30,60,60"  WidthRequest="80" HeightRequest="80"/>
+                    <ui:AcrylicView
+                        Grid.Column="2"
+                        BorderColor="Gray"
+                        BorderThickness="0,5,10,3"
+                        CornerRadius="10,30,60,60"
+                        EffectStyle="Custom"
+                        HeightRequest="80"
+                        TintColor="Blue"
+                        TintOpacity=".2"
+                        WidthRequest="80" />
 
-                    <ui:AcrylicView Grid.Column="3"  EffectStyle="Custom" BorderThickness="5,0" BorderColor="HotPink" TintColor="AliceBlue" TintOpacity=".3" CornerRadius="8,50" WidthRequest="80" HeightRequest="80"/>
+                    <ui:AcrylicView
+                        Grid.Column="3"
+                        BorderColor="HotPink"
+                        BorderThickness="5,0"
+                        CornerRadius="8,50"
+                        EffectStyle="Custom"
+                        HeightRequest="80"
+                        TintColor="AliceBlue"
+                        TintOpacity=".3"
+                        WidthRequest="80" />
 
                 </Grid>
 
             </Grid>
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
         </ScrollView>
 
     </Grid>

--- a/AcrylicView/AcrylicView.csproj
+++ b/AcrylicView/AcrylicView.csproj
@@ -32,7 +32,7 @@ AcrylicView, Windows,Android,iOS,Mac
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<PackageIcon>ico.png</PackageIcon>
+		<!--<PackageIcon>ico.png</PackageIcon>-->
 		<PackageId>AcrylicView.Maui</PackageId>
 	</PropertyGroup>
 
@@ -60,12 +60,12 @@ AcrylicView, Windows,Android,iOS,Mac
 	  <Folder Include="Platforms\Tizen\" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<!--<ItemGroup>
 	  <None Include="..\..\..\..\..\Desktop\Nuget\ico.png">
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
-	</ItemGroup>
+	</ItemGroup>-->
 
 
 	<!--<ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-android')) != true">

--- a/AcrylicView/Platforms/iOS/AcrylicViewHandler.cs
+++ b/AcrylicView/Platforms/iOS/AcrylicViewHandler.cs
@@ -95,15 +95,16 @@ namespace Xe.AcrylicView.Controls
                 return;
 
             var ver = UIDevice.CurrentDevice.SystemVersion;
-            if (!float.TryParse(ver, out float version))
-                return;
+            //if (!float.TryParse(ver, out float version))
+            //    return;
+
 
             var style = view.EffectStyle switch
             {
                 EffectStyle.Light => UIBlurEffectStyle.Light,
                 EffectStyle.Dark => UIBlurEffectStyle.Dark,
                 EffectStyle.ExtraLight => UIBlurEffectStyle.ExtraLight,
-                EffectStyle.ExtraDark => version >= 14.2 ? UIBlurEffectStyle.ExtraDark : UIBlurEffectStyle.Dark,
+                EffectStyle.ExtraDark => UIBlurEffectStyle.ExtraDark,
                 _ => UIBlurEffectStyle.Light
             };
             handler.acrylicEffectView.Effect = UIBlurEffect.FromStyle(style);


### PR DESCRIPTION
It seems that ExtraDark is supported on iOS 10+.  And Maui only supports iOS 11+. So I commented the TryParse line to check if the iOS version is greater than 14.2 and simply returned ExtraDark directly for ExtraDarkEffect Style.